### PR TITLE
Add Compact

### DIFF
--- a/acknack.go
+++ b/acknack.go
@@ -7,6 +7,8 @@ import (
 )
 
 func (q *Q) ack(id []byte) error {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
 	var wake bool
 	err := q.db.Update(func(tx *bolt.Tx) error {
 		var err error
@@ -30,6 +32,8 @@ func (q *Q) ack(id []byte) error {
 }
 
 func (q *Q) nack(id []byte, retry bool) error {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
 	var wake bool
 	err := q.db.Update(func(tx *bolt.Tx) (rerr error) {
 		bucket, err := q.bucket(tx, q.keys.unacked)

--- a/acknack_test.go
+++ b/acknack_test.go
@@ -124,7 +124,6 @@ func TestNackDeletesMessage_GH5(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	q.mu.RLock()
 	err = q.db.Update(func(tx *bolt.Tx) error {
 		bucket, err := q.bucket(tx, q.keys.unacked)
 		if err != nil {
@@ -136,7 +135,6 @@ func TestNackDeletesMessage_GH5(t *testing.T) {
 		}
 		return nil
 	})
-	q.mu.RUnlock()
 
 	if err != nil {
 		t.Fatal(err)

--- a/acknack_test.go
+++ b/acknack_test.go
@@ -124,6 +124,7 @@ func TestNackDeletesMessage_GH5(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	q.mu.RLock()
 	err = q.db.Update(func(tx *bolt.Tx) error {
 		bucket, err := q.bucket(tx, q.keys.unacked)
 		if err != nil {
@@ -135,6 +136,7 @@ func TestNackDeletesMessage_GH5(t *testing.T) {
 		}
 		return nil
 	})
+	q.mu.RUnlock()
 
 	if err != nil {
 		t.Fatal(err)

--- a/compact.go
+++ b/compact.go
@@ -1,0 +1,80 @@
+package lasr
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/boltdb/bolt"
+)
+
+// Compact performs compaction on the queue. All messages will be copied from
+// the underlying database into another.
+//
+// The queue is unavailable while compaction is occurring.
+//
+// Compaction causes the underlying bolt database to be replaced, so callers
+// should be aware that any other queues relying on the database may be
+// invalidated.
+func (q *Q) Compact() (rerr error) {
+	tf, err := ioutil.TempFile("", "")
+	if err != nil {
+		return fmt.Errorf("error compacting queue: %s", err)
+	}
+	_ = tf.Close()
+	newDB, err := bolt.Open(tf.Name(), 0644, nil)
+	if err != nil {
+		return fmt.Errorf("error compacting queue: %s", err)
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	err = q.db.Update(func(oldTx *bolt.Tx) error {
+		return newDB.Update(func(newTx *bolt.Tx) error {
+			oldBucket := oldTx.Bucket(q.name)
+			if oldBucket != nil {
+				newBucket, err := newTx.CreateBucket(q.name)
+				if err != nil {
+					return err
+				}
+				return copyNestedBucket(oldBucket, newBucket)
+			}
+			return nil
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("error compacting queue: %s", err)
+	}
+	dbPath := q.db.Path()
+	if err := q.db.Close(); err != nil {
+		return fmt.Errorf("error compacting queue: %s", err)
+	}
+	tempName := newDB.Path()
+	if err := newDB.Close(); err != nil {
+		return fmt.Errorf("error compacting queue: %s", err)
+	}
+	if err := os.Rename(tempName, dbPath); err != nil {
+		return fmt.Errorf("error compacting queue: %s", err)
+	}
+	q.db, err = bolt.Open(dbPath, 0644, nil)
+	if err != nil {
+		return fmt.Errorf("error compacting queue: %s", err)
+	}
+	return nil
+}
+
+func copyNestedBucket(old, new *bolt.Bucket) error {
+	return old.ForEach(func(k, v []byte) error {
+		if v != nil {
+			return new.Put(k, v)
+		}
+		nestedOld := old.Bucket(k)
+		if nestedOld == nil {
+			return new.Put(k, v)
+		}
+		nestedNew, err := new.CreateBucketIfNotExists(k)
+		if err != nil {
+			return err
+		}
+		return copyNestedBucket(nestedOld, nestedNew)
+	})
+}

--- a/compact_test.go
+++ b/compact_test.go
@@ -1,0 +1,38 @@
+package lasr
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestCompactDB(t *testing.T) {
+	q, _ := newQ(t)
+	// defer cleanup()
+	// TODO(eric): make cleanup work with Compact
+	for i := 0; i < 1000; i++ {
+		if _, err := q.Send([]byte(fmt.Sprintf("%d", i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 600; i++ {
+		if _, err := q.Receive(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldStats := q.db.Stats()
+	if err := q.Compact(); err != nil {
+		t.Fatal(err)
+	}
+	if msg, err := q.Receive(context.Background()); err != nil {
+		t.Fatal(err)
+	} else if len(msg.Body) == 0 {
+		t.Fatal("message length zero")
+	}
+	newStats := q.db.Stats()
+	oldPages := oldStats.TxStats.PageCount
+	newPages := newStats.TxStats.PageCount
+	if oldPages <= newPages {
+		t.Fatalf("expected fewer pages in new db (%d old, %d new)", oldPages, newPages)
+	}
+}

--- a/compact_test.go
+++ b/compact_test.go
@@ -35,4 +35,11 @@ func TestCompactDB(t *testing.T) {
 	if oldPages <= newPages {
 		t.Fatalf("expected fewer pages in new db (%d old, %d new)", oldPages, newPages)
 	}
+	for i := 0; i < 399; i++ {
+		if msg, err := q.Receive(context.Background()); err != nil {
+			t.Fatal(err)
+		} else if len(msg.Body) == 0 {
+			t.Fatal("message length zero")
+		}
+	}
 }

--- a/lasr.go
+++ b/lasr.go
@@ -21,6 +21,7 @@ type Q struct {
 	inFlight    sync.WaitGroup
 	waker       *waker
 	optsApplied bool
+	mu          sync.RWMutex
 }
 
 type bucketKeys struct {
@@ -62,7 +63,8 @@ func (q *Q) String() string {
 	return fmt.Sprintf("Q{Name: %q}", string(q.name))
 }
 
-// NewQ creates a new Q.
+// NewQ creates a new Q. Only one queue should be created in a given bolt db,
+// unless compaction is disabled.
 func NewQ(db *bolt.DB, name string, options ...Option) (*Q, error) {
 	bName := []byte(name)
 	closed := make(chan struct{})
@@ -100,6 +102,8 @@ func (q *Q) init() error {
 }
 
 func (q *Q) equilibrate() error {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
 	return q.db.Update(func(tx *bolt.Tx) error {
 		bucket, err := q.bucket(tx, q.keys.ready)
 		if err != nil {

--- a/options.go
+++ b/options.go
@@ -1,6 +1,8 @@
 package lasr
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Options can be passed to NewQ.
 type Option func(q *Q) error

--- a/sendreceive.go
+++ b/sendreceive.go
@@ -15,6 +15,7 @@ func (q *Q) Send(message []byte) (ID, error) {
 		return nil, ErrQClosed
 	}
 	var id ID
+	q.mu.RLock()
 	err := q.db.Update(func(tx *bolt.Tx) (err error) {
 		id, err = q.nextSequence(tx)
 		if err != nil {
@@ -22,6 +23,7 @@ func (q *Q) Send(message []byte) (ID, error) {
 		}
 		return q.send(id, message, tx)
 	})
+	q.mu.RUnlock()
 	if err == nil {
 		q.waker.Wake()
 	}

--- a/sendreceive_test.go
+++ b/sendreceive_test.go
@@ -129,6 +129,7 @@ func TestUnacked(t *testing.T) {
 	q.inFlight = sync.WaitGroup{}
 
 	// Make sure the unacked message is in the unacked queue
+	q.mu.RLock()
 	err = q.db.Update(func(tx *bolt.Tx) error {
 		bucket, err := q.bucket(tx, q.keys.unacked)
 		if err != nil {
@@ -144,6 +145,7 @@ func TestUnacked(t *testing.T) {
 		}
 		return nil
 	})
+	q.mu.RUnlock()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wait.go
+++ b/wait.go
@@ -14,6 +14,8 @@ func (q *Q) Wait(msg []byte, on ...ID) (ID, error) {
 		return q.Send(msg)
 	}
 	var id ID
+	q.mu.RLock()
+	defer q.mu.RUnlock()
 	return id, q.db.Update(func(tx *bolt.Tx) error {
 		var err error
 		id, err = q.nextSequence(tx)


### PR DESCRIPTION
Compact will reduce the size of the on-disk queue database, if the
queue was previously very large.

Signed-off-by: Eric Chlebek <eric@sensu.io>